### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/sc4/security/code-scanning/11](https://github.com/kelsoncm/sc4/security/code-scanning/11)

Add an explicit top-level `permissions` block so all jobs get a safe default (`contents: read`), while preserving existing job-specific overrides (deploy jobs already define their own permissions and will continue to do so).

Best single fix without changing functionality:
- Edit `.github/workflows/pythonapp.yml`
- Insert after the `on:` triggers (before `jobs:`) a root-level:
  - `permissions:`
  - `contents: read`

This resolves the CodeQL finding for jobs lacking explicit permissions (`quality`, `test`) and keeps deploy jobs unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
