### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/sc4net/tests/mocks.py
+++ b/sc4net/tests/mocks.py
@@ -76,7 +76,12 @@ class MockHttpServerRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         parts = self.path.split("/")
         filepath = parts[len(parts) - 1]
-        full_file_name = os.path.realpath(os.path.join(dir_path, filepath))
+        safe_filepath = os.path.basename(os.path.normpath(filepath))
+        if safe_filepath in ("", ".", ".."):
+            self.send_error(404, FILE_NOT_FOUND_ERROR_MESSAGE)
+            return
+
+        full_file_name = os.path.realpath(os.path.join(dir_path, safe_filepath))
 
         if os.path.commonpath([dir_path, full_file_name]) != dir_path:
             self.send_error(404, FILE_NOT_FOUND_ERROR_MESSAGE)


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/sc4/security/code-scanning/1](https://github.com/kelsoncm/sc4/security/code-scanning/1)

Use explicit filename sanitization/validation before path construction, while keeping behavior the same for valid test asset files.

Best fix in this file:
- In `do_GET` (around lines 76–80), normalize and reduce user input to a safe basename (`os.path.basename(os.path.normpath(...))`), reject empty or special names (`"."`, `".."`), then build the path from this sanitized value.
- Keep existing `realpath` + `commonpath` guard as an additional safety layer.
- No new dependencies are needed; `os` is already imported.

This addresses the CodeQL flow by ensuring uncontrolled path content is constrained before use in filesystem path expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
