### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/sc4net/tests/mocks.py
+++ b/sc4net/tests/mocks.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 
 import os
+import re
 import threading
 
 # import socket
@@ -76,8 +77,11 @@ class MockHttpServerRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         parts = self.path.split("/")
         filepath = parts[len(parts) - 1]
-        safe_filepath = os.path.basename(os.path.normpath(filepath))
-        if safe_filepath in ("", ".", ".."):
+        safe_filepath = os.path.basename(filepath)
+        if (
+            safe_filepath in ("", ".", "..")
+            or not re.fullmatch(r"[A-Za-z0-9._-]+", safe_filepath)
+        ):
             self.send_error(404, FILE_NOT_FOUND_ERROR_MESSAGE)
             return
 

--- a/sc4net/tests/mocks.py
+++ b/sc4net/tests/mocks.py
@@ -78,9 +78,8 @@ class MockHttpServerRequestHandler(BaseHTTPRequestHandler):
         parts = self.path.split("/")
         filepath = parts[len(parts) - 1]
         safe_filepath = os.path.basename(filepath)
-        if (
-            safe_filepath in ("", ".", "..")
-            or not re.fullmatch(r"[A-Za-z0-9._-]+", safe_filepath)
+        if safe_filepath in ("", ".", "..") or not re.fullmatch(
+            r"[A-Za-z0-9._-]+", safe_filepath
         ):
             self.send_error(404, FILE_NOT_FOUND_ERROR_MESSAGE)
             return


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/sc4/security/code-scanning/1](https://github.com/kelsoncm/sc4/security/code-scanning/1)

To fix this robustly without changing intended functionality, enforce a strict filename allowlist before building the file path (only plain filenames with safe characters, no separators), and continue using the existing canonicalization + containment check. This removes ambiguity and makes the sanitization explicit to both humans and static analyzers.

In `sc4net/tests/mocks.py`, update `do_GET`:
- after extracting `filepath`, derive `safe_filepath` with `os.path.basename(filepath)` (single-file semantics),
- reject invalid names via a regex allowlist (e.g., `^[A-Za-z0-9._-]+$`),
- keep the existing `realpath(join(...))` and `commonpath` checks,
- then proceed with `exists`/`open`.

Also add `import re` at the top for validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
